### PR TITLE
Bytes | IO::Memory constructor, Database#model? methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/doc/
+/docs/
 /lib/
 /bin/
 /.shards/

--- a/spec/database_spec.cr
+++ b/spec/database_spec.cr
@@ -35,6 +35,8 @@ describe GeoIP2::Database do
   it "unknown ip address" do
     database = GeoIP2.open(db_path("GeoIP2-City-Test"))
 
+    database.city?("10.10.10.10").should be_nil
+
     expect_raises(GeoIP2::AddressNotFoundError, "The address '10.10.10.10' is not in the database") do
       database.city("10.10.10.10")
     end

--- a/spec/database_spec.cr
+++ b/spec/database_spec.cr
@@ -166,5 +166,23 @@ describe GeoIP2::Database do
       record.organization.should eq("Telstra Internet")
       record.ip_address.should eq("1.128.0.0")
     end
+
+    it "loads database from Bytes" do
+      bytes : Bytes = db_bytes("GeoIP2-Domain-Test")
+      database = GeoIP2.open(bytes)
+
+      record = database.domain("1.2.0.0")
+      record.domain.should eq("maxmind.com")
+      record.ip_address.should eq("1.2.0.0")
+    end
+
+    it "loads database from IO::Memory" do
+      memory = IO::Memory.new(db_bytes("GeoIP2-Domain-Test"))
+      database = GeoIP2.open(memory)
+
+      record = database.domain("1.2.0.0")
+      record.domain.should eq("maxmind.com")
+      record.ip_address.should eq("1.2.0.0")
+    end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -5,6 +5,19 @@ def db_path(name : String)
   "spec/data/test-data/#{name}.mmdb"
 end
 
+def db_bytes(name : String)
+  file = File.new(db_path(name), "rb")
+  bytes = Bytes.new(file.size)
+
+  begin
+    file.read_fully(bytes)
+  ensure
+    file.close
+  end
+
+  bytes
+end
+
 def source_model_data(file_name, ip_address)
   source_path = "spec/data/source-data/#{file_name}.json"
   source_data = File.read(source_path)

--- a/src/geoip2.cr
+++ b/src/geoip2.cr
@@ -3,7 +3,7 @@ require "./geoip2/database"
 require "./geoip2/version"
 
 module GeoIP2
-  def self.open(db_path : String, locales : Array(String) = ["en"])
-    Database.new(db_path, locales)
+  def self.open(db : String | Bytes | IO::Memory, locales : Array(String) = ["en"])
+    Database.new(db, locales)
   end
 end

--- a/src/geoip2/database.cr
+++ b/src/geoip2/database.cr
@@ -7,67 +7,45 @@ module GeoIP2
       @reader = MaxMindDB.open(db)
     end
 
-    def city(ip_address : String)
-      model "City", "City", ip_address
+    private macro def_model(name, database_type)
+      # Returns `Model::{{name.id}}` or `nil` if ip_address is not in the database
+      def {{name.id.underscore}}?(ip_address : String) : Model::{{name.id}}?
+        unless metadata.database_type.includes?({{database_type}})
+          raise ArgumentError.new(
+            "The '#{{{name.underscore}}}' method cannot be used" +
+            " with the '#{metadata.database_type}' database"
+          )
+        end
+        record = @reader.get(ip_address)
+
+        return nil if record.empty?
+
+        Model::{{name.id}}.new(record, @locales, ip_address)
+      end
+
+      # Returns `Model::{{name.id}}` or raises `AddressNotFoundError` if ip_address is not in the database
+      def {{name.id.underscore}}(ip_address : String) : Model::{{name.id}}
+        model = {{name.id.underscore}}?(ip_address)
+        if model.nil?
+          raise AddressNotFoundError.new("The address '#{ip_address}' is not in the database")
+        end
+        model
+      end
     end
 
-    def country(ip_address : String)
-      model "Country", "Country", ip_address
-    end
-
-    def enterprise(ip_address : String)
-      model "Enterprise", "Enterprise", ip_address
-    end
-
-    def anonymous_ip(ip_address : String)
-      model "AnonymousIp", "Anonymous-IP", ip_address
-    end
-
-    def asn(ip_address : String)
-      model "Asn", "ASN", ip_address
-    end
-
-    def connection_type(ip_address : String)
-      model "ConnectionType", "Connection-Type", ip_address
-    end
-
-    def domain(ip_address : String)
-      model "Domain", "Domain", ip_address
-    end
-
-    def isp(ip_address : String)
-      model "Isp", "ISP", ip_address
-    end
-
-    def user_count(ip_address : String)
-      model "UserCount", "User-Count", ip_address
-    end
-
-    def density_income(ip_address : String)
-      model "DensityIncome", "DensityIncome", ip_address
-    end
+    def_model "City", "City"
+    def_model "Country", "Country"
+    def_model "Enterprise", "Enterprise"
+    def_model "AnonymousIp", "Anonymous-IP"
+    def_model "Asn", "ASN"
+    def_model "ConnectionType", "Connection-Type"
+    def_model "Domain", "Domain"
+    def_model "Isp", "ISP"
+    def_model "UserCount", "User-Count"
+    def_model "DensityIncome", "DensityIncome"
 
     def metadata
       @reader.metadata
-    end
-
-    private macro model(name, database_type, ip_address)
-      unless metadata.database_type.includes?({{database_type}})
-        raise ArgumentError.new(
-                "The '#{{{name.underscore}}}' method cannot be used" +
-                " with the '#{metadata.database_type}' database"
-              )
-      end
-
-      record = @reader.get({{ip_address}})
-
-      if record.empty?
-        raise AddressNotFoundError.new(
-                "The address '#{ip_address}' is not in the database"
-              )
-      end
-
-      Model::{{name.id}}.new(record, @locales, ip_address)
     end
   end
 end

--- a/src/geoip2/database.cr
+++ b/src/geoip2/database.cr
@@ -3,8 +3,8 @@ require "./model"
 
 module GeoIP2
   class Database
-    def initialize(db_path : String, @locales : Array(String))
-      @reader = MaxMindDB.open(db_path)
+    def initialize(db : String | Bytes | IO::Memory, @locales : Array(String))
+      @reader = MaxMindDB.open(db)
     end
 
     def city(ip_address : String)
@@ -66,7 +66,7 @@ module GeoIP2
                 "The address '#{ip_address}' is not in the database"
               )
       end
-      
+
       Model::{{name.id}}.new(record, @locales, ip_address)
     end
   end


### PR DESCRIPTION
I hope combining both of these in one PR is fine. Besides the small constructor change, this adds additional database methods that don't throw an expection but return `nil` instead (like `country?`, `city?` and so on).